### PR TITLE
remove custom category handler

### DIFF
--- a/packages/gfw-blog/src/index.js
+++ b/packages/gfw-blog/src/index.js
@@ -220,7 +220,7 @@ const marsTheme = {
       processors: [image, iframe, gutenbergGallery, blockquote],
     },
     source: {
-      handlers: [allCategoriesHandler, topTagsHandler, categoryOrPostHandler, stickyPostsHandler],
+      handlers: [allCategoriesHandler, topTagsHandler, stickyPostsHandler],
     },
   },
 };


### PR DESCRIPTION
removes the custom category post handler to fix head tags plugin