### PR TITLE
Add a noindex metatag to the staging environment

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -21,6 +21,8 @@ export default class MyDocument extends Document {
   }
 
   render() {
+    const isProduction = process.env.NEXT_PUBLIC_FEATURE_ENV === 'production';
+
     return (
       <Html>
         <Head>
@@ -55,6 +57,7 @@ export default class MyDocument extends Document {
             name="google-site-verification"
             content="xx82D6cZ40Hvf-TT9jkhfsVi11yIeShPcK0zcc7m7ak"
           />
+          {!isProduction && <meta name="robots" content="noindex,follow" />}
           <link
             href="https://fonts.googleapis.com/css2?family=Fira+Sans:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400;1,500;1,600&display=swap"
             rel="stylesheet"


### PR DESCRIPTION
## Overview

This PR adds a `noindex` metatag to the header of the pages when on the `staging` environment.

## Notes  

Both [gfw](https://github.com/Vizzuality/gfw) and [gfw-help-center](https://github.com/Vizzuality/gfw-blog) have a `NEXT_PUBLIC_FEATURE_ENV` config var set up on Heroku. `gfw-blog` does not, so I've added it there so we can check whether we're running in `production` or not in the code. 

## Demo

https://gfw-blog-pr-67.herokuapp.com/blog/

## Tracking  

[FLAG-136](https://gfw.atlassian.net/browse/FLAG-136)