### PR TITLE
Add LCL logo next to WRI logo in the footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "emotion-server": "^10.0.27",
     "express": "^4.17.1",
     "heroku-ssl-redirect": "^0.1.1",
-    "gfw-components": "^1.8.5",
+    "gfw-components": "^1.8.6",
     "husky": "^4.3.0",
     "image-trace-loader": "^1.0.2",
     "imagemin-mozjpeg": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "emotion-server": "^10.0.27",
     "express": "^4.17.1",
     "heroku-ssl-redirect": "^0.1.1",
-    "gfw-components": "^1.8.7",
+    "gfw-components": "^1.8.8",
     "husky": "^4.3.0",
     "image-trace-loader": "^1.0.2",
     "imagemin-mozjpeg": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "emotion-server": "^10.0.27",
     "express": "^4.17.1",
     "heroku-ssl-redirect": "^0.1.1",
-    "gfw-components": "^1.8.8",
+    "gfw-components": "^1.8.9",
     "husky": "^4.3.0",
     "image-trace-loader": "^1.0.2",
     "imagemin-mozjpeg": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "emotion-server": "^10.0.27",
     "express": "^4.17.1",
     "heroku-ssl-redirect": "^0.1.1",
-    "gfw-components": "^1.8.6",
+    "gfw-components": "^1.8.7",
     "husky": "^4.3.0",
     "image-trace-loader": "^1.0.2",
     "imagemin-mozjpeg": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5443,10 +5443,10 @@ gettext-parser@^1.3.1:
     encoding "^0.1.12"
     safe-buffer "^5.1.1"
 
-gfw-components@^1.8.5:
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/gfw-components/-/gfw-components-1.8.5.tgz#40ab572955ba84d34337edc5a0f8d374b07bbdc6"
-  integrity sha512-FiCQIasQo37oJO2kdVNmtg6Dczy9RuJDYPvWCCGsY/eU6lCb1O5BHUKoJP0qV9h/Bzb6lRZxIjjIDTzw6PtvUg==
+gfw-components@^1.8.6:
+  version "1.8.6"
+  resolved "https://registry.yarnpkg.com/gfw-components/-/gfw-components-1.8.6.tgz#446c66eb6bf3f16233f7de56d6c60ba47669c930"
+  integrity sha512-717RZgasltILn7OFEIvWvGiKyUoWNragw68wdPLGIpaMx1/AyT4dN1BMeC/a964bTM7kLe5KT3EJvWv0DRIb8g==
   dependencies:
     "@artsy/fresnel" "^1.1.0"
     "@tippyjs/react" "^4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5443,10 +5443,10 @@ gettext-parser@^1.3.1:
     encoding "^0.1.12"
     safe-buffer "^5.1.1"
 
-gfw-components@^1.8.8:
-  version "1.8.8"
-  resolved "https://registry.yarnpkg.com/gfw-components/-/gfw-components-1.8.8.tgz#55816b94498781a9986b1e6c5aace6ccaf6ef016"
-  integrity sha512-TzP5wMnjRfxqGZRptBPFkUNL1I0B/wNHm/oq+FefXxhRboU5kw34lRJqPeOBb94tot8P77A5eJpC1s/6fbOZUg==
+gfw-components@^1.8.9:
+  version "1.8.9"
+  resolved "https://registry.yarnpkg.com/gfw-components/-/gfw-components-1.8.9.tgz#8aac90c8e3c732926787eff6a54344c0b17cc5e1"
+  integrity sha512-NK4i+75P76iZ6YridmKt5EnTl0kb1KQlk25ygdLpHVliWq4W0hi9TIaBv7zQudltNJmyFZ2HBFefS2sfVwPTSg==
   dependencies:
     "@artsy/fresnel" "^1.1.0"
     "@tippyjs/react" "^4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5443,10 +5443,10 @@ gettext-parser@^1.3.1:
     encoding "^0.1.12"
     safe-buffer "^5.1.1"
 
-gfw-components@^1.8.6:
-  version "1.8.6"
-  resolved "https://registry.yarnpkg.com/gfw-components/-/gfw-components-1.8.6.tgz#446c66eb6bf3f16233f7de56d6c60ba47669c930"
-  integrity sha512-717RZgasltILn7OFEIvWvGiKyUoWNragw68wdPLGIpaMx1/AyT4dN1BMeC/a964bTM7kLe5KT3EJvWv0DRIb8g==
+gfw-components@^1.8.7:
+  version "1.8.7"
+  resolved "https://registry.yarnpkg.com/gfw-components/-/gfw-components-1.8.7.tgz#53cc5ac308db83b80881f60ceb67198ef40d196e"
+  integrity sha512-agQEe7Dba1ByC8lVVT5/j2uqLlBxYxY+q5aznqQSPyBGofAHKDwQ1FBEauzlUPIm9PrK0+hdBEqMnnxLpFOS5A==
   dependencies:
     "@artsy/fresnel" "^1.1.0"
     "@tippyjs/react" "^4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5443,10 +5443,10 @@ gettext-parser@^1.3.1:
     encoding "^0.1.12"
     safe-buffer "^5.1.1"
 
-gfw-components@^1.8.7:
-  version "1.8.7"
-  resolved "https://registry.yarnpkg.com/gfw-components/-/gfw-components-1.8.7.tgz#53cc5ac308db83b80881f60ceb67198ef40d196e"
-  integrity sha512-agQEe7Dba1ByC8lVVT5/j2uqLlBxYxY+q5aznqQSPyBGofAHKDwQ1FBEauzlUPIm9PrK0+hdBEqMnnxLpFOS5A==
+gfw-components@^1.8.8:
+  version "1.8.8"
+  resolved "https://registry.yarnpkg.com/gfw-components/-/gfw-components-1.8.8.tgz#55816b94498781a9986b1e6c5aace6ccaf6ef016"
+  integrity sha512-TzP5wMnjRfxqGZRptBPFkUNL1I0B/wNHm/oq+FefXxhRboU5kw34lRJqPeOBb94tot8P77A5eJpC1s/6fbOZUg==
   dependencies:
     "@artsy/fresnel" "^1.1.0"
     "@tippyjs/react" "^4.0.2"


### PR DESCRIPTION
## Overview

This PR bumps the `gfw-components` version to the new one with the LCL logo next to WRI's logo in the footer. 

## Tracking 

[FLAG-550](https://gfw.atlassian.net/browse/FLAG-550)

## Screenshot

<img width="1129" alt="Screenshot 2022-11-30 at 11 31 51" src="https://user-images.githubusercontent.com/6273795/204785656-2995d10d-35f6-49cf-b29d-8f307ae78725.png">


