### PR TITLE
Allow setting canonical links via the Yoast SEO plugin

### DIFF
--- a/layouts/layout/index.js
+++ b/layouts/layout/index.js
@@ -8,7 +8,11 @@ import ReactHtmlParser from 'react-html-parser';
 import has from 'lodash/has';
 
 import { LangProvider, getAPILangCode } from 'utils/lang';
-import { serializeYoast, ensureTrailingSlash } from 'utils/content';
+import {
+  getCanonicalLink,
+  serializeYoast,
+  ensureTrailingSlash,
+} from 'utils/content';
 
 import {
   GlobalStyles,
@@ -50,43 +54,19 @@ const renderPage = (isError, statusCode, children, preview, lang) => (
   </>
 );
 
-const renderCanonical = (post = null, tax = null) => {
-  if (post?.link) {
-    return (
-      <link
-        rel="canonical"
-        href={`https://www.globalforestwatch.org/blog${ensureTrailingSlash(
-          post.link
-        )}`}
-      />
-    );
-  }
-  if (tax?.link) {
-    return (
-      <link
-        rel="canonical"
-        href={`https://www.globalforestwatch.org/blog${ensureTrailingSlash(
-          tax.link
-        )}`}
-      />
-    );
-  }
-  return (
-    <link rel="canonical" href="https://www.globalforestwatch.org/blog/" />
-  );
-};
+export default function Layout(props) {
+  const {
+    children,
+    metaTags,
+    isError,
+    statusCode,
+    preview,
+    noIndex,
+    post,
+    tax,
+    slugs,
+  } = props;
 
-export default function Layout({
-  children,
-  metaTags,
-  isError,
-  statusCode,
-  preview,
-  noIndex,
-  post,
-  tax,
-  slugs,
-}) {
   const [open, setOpen] = useState(false);
   const [language, setLanguage] = useState('en');
   const { isFallback, push } = useRouter();
@@ -144,6 +124,7 @@ export default function Layout({
   };
 
   const isProduction = process.env.NEXT_PUBLIC_FEATURE_ENV === 'production';
+  const canonicalLink = getCanonicalLink({ metaTags, post, tax });
 
   return (
     <>
@@ -152,6 +133,7 @@ export default function Layout({
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=5"
         />
+        <link rel="canonical" href={canonicalLink} />
         {metaTags && ReactHtmlParser(serializeYoast(metaTags))}
         {/* ld+json tags from yoast */}
         {getYoastGraph()}
@@ -205,7 +187,6 @@ export default function Layout({
               />
             );
           })}
-        {renderCanonical(post, tax)}
       </Head>
       <GlobalStyles />
       <HeaderWrapper>

--- a/layouts/layout/index.js
+++ b/layouts/layout/index.js
@@ -10,8 +10,8 @@ import has from 'lodash/has';
 import { LangProvider, getAPILangCode } from 'utils/lang';
 import {
   getCanonicalLink,
-  serializeYoast,
   ensureTrailingSlash,
+  parseYoast,
 } from 'utils/content';
 
 import {
@@ -57,14 +57,13 @@ const renderPage = (isError, statusCode, children, preview, lang) => (
 export default function Layout(props) {
   const {
     children,
-    metaTags,
     isError,
     statusCode,
     preview,
     noIndex,
     post,
-    tax,
     slugs,
+    metaTags: yoast,
   } = props;
 
   const [open, setOpen] = useState(false);
@@ -110,7 +109,7 @@ export default function Layout(props) {
       : [];
 
   const getYoastGraph = () => {
-    const graph = serializeYoastGraph(metaTags, breadcrumbs);
+    const graph = serializeYoastGraph(yoast, breadcrumbs);
     if (graph) {
       return (
         <script
@@ -124,7 +123,8 @@ export default function Layout(props) {
   };
 
   const isProduction = process.env.NEXT_PUBLIC_FEATURE_ENV === 'production';
-  const canonicalLink = getCanonicalLink({ metaTags, post, tax });
+  const canonicalLink = getCanonicalLink(yoast);
+  const yoastMetaTags = ReactHtmlParser(parseYoast(yoast));
 
   return (
     <>
@@ -133,8 +133,8 @@ export default function Layout(props) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=5"
         />
+        {yoastMetaTags}
         <link rel="canonical" href={canonicalLink} />
-        {metaTags && ReactHtmlParser(serializeYoast(metaTags))}
         {/* ld+json tags from yoast */}
         {getYoastGraph()}
         {(!isProduction || noIndex || isError) && (
@@ -243,5 +243,4 @@ Layout.propTypes = {
   preview: PropTypes.bool,
   noIndex: PropTypes.bool,
   post: PropTypes.object,
-  tax: PropTypes.object,
 };

--- a/utils/content.js
+++ b/utils/content.js
@@ -13,9 +13,11 @@ export const ensureTrailingSlash = (str) => {
   return `${str}/`;
 };
 
-export const serializeYoast = (yoast) => {
-  return yoast
-    .replace(/<link rel="canonical" .* \/>/, '') // we render this ourselves
+/**
+ * Replaces the possible blog urls (stemming by the different possible environments) with the correct one.
+ */
+export const replaceBlogUrls = (metaTags) => {
+  return metaTags
     .replace(
       /https:\/\/www.globalforestwatch.org\/(blog\/?)?/g, // /blog/ might not be present, and has to be added if thats the case.
       `${BLOG_LINK}/`
@@ -27,15 +29,21 @@ export const serializeYoast = (yoast) => {
     .replace(/https:\/\/blog.globalforestwatch.org/g, BLOG_LINK);
 };
 
+export const parseYoast = (yoast = '') => {
+  return replaceBlogUrls(
+    yoast?.replace(/<link rel="canonical" .* \/>/, '') // we render this ourselves
+  );
+};
+
 /**
  * Returns the canonical link to be used in the page.
  * If one is set in Yoast, we use it. If not, we'll use either the post or tax link.
  * If no links are available, we can assume we're on the /blog page.
  */
-export const getCanonicalLink = ({ metaTags }) => {
-  const yoastCanonicalLink = (metaTags?.match(
+export const getCanonicalLink = (yoast) => {
+  const yoastCanonicalLink = (yoast?.match(
     /<link rel="canonical" href="(.*)" \/>/
   ) || [])[1];
 
-  return ensureTrailingSlash(serializeYoast(yoastCanonicalLink || BLOG_LINK)); // BLOG_LINK is just a failsafe
+  return ensureTrailingSlash(replaceBlogUrls(yoastCanonicalLink || BLOG_LINK)); // BLOG_LINK is just a failsafe
 };

--- a/utils/content.js
+++ b/utils/content.js
@@ -27,3 +27,18 @@ export const serializeYoast = (yoast) => {
       'https://www.globalforestwatch.org/blog'
     );
 };
+
+/**
+ * Returns the canonical link to be used in the page.
+ * If one is set in Yoast, we use it. If not, we'll use either the post or tax link.
+ * If no links are available, we can assume we're on the /blog page.
+ */
+export const getCanonicalLink = ({ metaTags }) => {
+  const blogLink = 'https://www.globalforestwatch.org/blog';
+
+  const yoastCanonicalLink = (metaTags?.match(
+    /<link rel="canonical" href="(.*)" \/>/
+  ) || [])[1];
+
+  return ensureTrailingSlash(serializeYoast(yoastCanonicalLink || blogLink)); // blogLink is just a failsafe
+};

--- a/utils/content.js
+++ b/utils/content.js
@@ -1,3 +1,5 @@
+const BLOG_LINK = 'https://www.globalforestwatch.org/blog';
+
 export const clearExcerptHellip = (str) => {
   return str.replace(/(\[(&hellip;)\])<\/.>/, '$2');
 };
@@ -16,16 +18,13 @@ export const serializeYoast = (yoast) => {
     .replace(/<link rel="canonical" .* \/>/, '') // we render this ourselves
     .replace(
       /https:\/\/www.globalforestwatch.org\/(blog\/?)?/g, // /blog/ might not be present, and has to be added if thats the case.
-      'https://www.globalforestwatch.org/blog/'
+      `${BLOG_LINK}/`
     )
     .replace(
       /https:\/\/content.globalforestwatch.org\/global-forest-watch-blog/g,
-      'https://www.globalforestwatch.org/blog'
+      BLOG_LINK
     )
-    .replace(
-      /https:\/\/blog.globalforestwatch.org/g,
-      'https://www.globalforestwatch.org/blog'
-    );
+    .replace(/https:\/\/blog.globalforestwatch.org/g, BLOG_LINK);
 };
 
 /**
@@ -34,11 +33,9 @@ export const serializeYoast = (yoast) => {
  * If no links are available, we can assume we're on the /blog page.
  */
 export const getCanonicalLink = ({ metaTags }) => {
-  const blogLink = 'https://www.globalforestwatch.org/blog';
-
   const yoastCanonicalLink = (metaTags?.match(
     /<link rel="canonical" href="(.*)" \/>/
   ) || [])[1];
 
-  return ensureTrailingSlash(serializeYoast(yoastCanonicalLink || blogLink)); // blogLink is just a failsafe
+  return ensureTrailingSlash(serializeYoast(yoastCanonicalLink || BLOG_LINK)); // BLOG_LINK is just a failsafe
 };


### PR DESCRIPTION
## Overview  

This PR makes it so that canonical URLs can be set/overridden by the Yoast SEO WP plugin.   

## Notes  

While investigating the ticket, I noticed the code didn't consider the canonical url set via Yoast SEO plugin. Instead, it was setting it based on the post (or categories) page's url, thus not allowing the canonical link to be customised/overridden, hence the bug. 

The solution implemented was to _always_ use the canonical URL sent by the Wordpress API, taking into account possible URL transformations that need to be made (eg: ensuring trailing slashes) as this works for both post and category pages and allows for a canonical URL to be set via the Yoast SEO plugin. 

## Tracking

[FLAG-564](https://gfw.atlassian.net/browse/FLAG-564)

## Testing instructions  

1. Verify that blog posts in which a canonical link was set, have the correct URL set
    1. Open `/blog/data-and-research/worlds-last-intact-forests-are-becoming-increasingly-fragmented/`
    2. Check that there is a canonical URL set via Yoast SEO:   
        - Go to WP Admin  
        - Open the corresponding blog post  
        - Click the top right Yoast SEO icon to toggle its sidebar, if not already active  
        - Open the _"Advanced"_ section  
        - The URL is under _"Canonical URL"_
     3. Ensure the URL matches the one set by the Yoast SEO plugin
2. Verify that blog posts in which a canonical link was *not* set, have the blog post's url as a canonical link  
    1. Open `/blog/data-and-research/trends-tree-loss-from-fires-unprecedented-detail/`
    2. Ensure no URL is set via Yoast SEO:
        - Follow the steps from 1. ii.  
    3. Ensure the URL matches `https://www.globalforestwatch.org/blog/data-and-research/trends-tree-loss-from-fires-unprecedented-detail/`
3. Verify that when visiting `blog` the correct canonical URL is set
    1. Open `/blog`  
    2. Ensure the URL matches `https://www.globalforestwatch.org/blog/`
4. Verify that when visiting Category pages the correct URL is set  
    1. Open `/blog/data-and-research/`  
    2. Ensure the URL matches `https://www.globalforestwatch.org/blog/data-and-research/`