### PR TITLE
Replace link to MapBuilder website in main menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "emotion-server": "^10.0.27",
     "express": "^4.17.1",
     "heroku-ssl-redirect": "^0.1.1",
-    "gfw-components": "^1.8.5",
+    "gfw-components": "^1.8.10",
     "husky": "^4.3.0",
     "image-trace-loader": "^1.0.2",
     "imagemin-mozjpeg": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5443,10 +5443,10 @@ gettext-parser@^1.3.1:
     encoding "^0.1.12"
     safe-buffer "^5.1.1"
 
-gfw-components@^1.8.5:
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/gfw-components/-/gfw-components-1.8.5.tgz#40ab572955ba84d34337edc5a0f8d374b07bbdc6"
-  integrity sha512-FiCQIasQo37oJO2kdVNmtg6Dczy9RuJDYPvWCCGsY/eU6lCb1O5BHUKoJP0qV9h/Bzb6lRZxIjjIDTzw6PtvUg==
+gfw-components@^1.8.10:
+  version "1.8.10"
+  resolved "https://registry.yarnpkg.com/gfw-components/-/gfw-components-1.8.10.tgz#1c7fd9033557d8b47dd5eeaa075bcb0e37590f67"
+  integrity sha512-5+mPaqI3gJZN5899YyZZWGUP3noaSEwC7zrl6zd2nbP11pS5a+PVHECQ3haUf6F9hG74EoZ/pD7D4A52gxjWqg==
   dependencies:
     "@artsy/fresnel" "^1.1.0"
     "@tippyjs/react" "^4.0.2"


### PR DESCRIPTION
## Overview

This PR bumps the `gfw-components` version to `1.8.10` in order to get the header version in which the `mapbuilder` link is the new map builder website. 

## Testing

1. Visit https://gfw-blog-pr-74.herokuapp.com/blog/
2. On the navigation menu
    1. Click _"MORE"_
    2. Verify that the _"MAPBUILDER"_ link under _"MORE IN GFW"_ directly links to http://mapbuilder.wri.org/

