### PR TITLE
Set up http/https and non-www/www redirects

### DIFF
--- a/server.js
+++ b/server.js
@@ -38,7 +38,8 @@ function handleNonWwwToWwwRedirect(req, res) {
 app.prepare().then(() => {
   const server = express();
 
-  server.use(sslRedirect());
+  // Redirect from http to https when NODE_ENV is set to `production`.
+  server.use(sslRedirect(['production'], 301));
 
   server.all(/.*/, (req, res) => {
     // Redirect from non-www to www, but only on actual `production`.

--- a/server.js
+++ b/server.js
@@ -2,7 +2,7 @@ const next = require('next');
 const express = require('express');
 const sslRedirect = require('heroku-ssl-redirect').default;
 
-const port = parseInt(process.env.PORT, 10) || 9090;
+const port = parseInt(process.env.PORT, 10) || 3000;
 const dev = process.env.NODE_ENV !== 'production';
 const app = next({ dev });
 const handle = app.getRequestHandler();

--- a/server.js
+++ b/server.js
@@ -7,19 +7,50 @@ const dev = process.env.NODE_ENV !== 'production';
 const app = next({ dev });
 const handle = app.getRequestHandler();
 
+/**
+ * Handles redirects from the original blog url to the current one
+ */
+function handleOldBlogUrlRedirect(req, res) {
+  try {
+    const host = req.get('host');
+    if (host === 'blog.globalforestwatch.org') {
+      res.redirect(301, `https://www.${host}/blog${req.originalUrl}`);
+    }
+  } catch (_i) {
+    // Ignore by default
+  }
+}
+
+/**
+ * Redirects non-www urls to www urls
+ */
+function handleNonWwwToWwwRedirect(req, res) {
+  try {
+    const host = req.header('host');
+    if (!host.match(/^www\..*/i)) {
+      res.redirect(301, `https://www.${host}${req.url}`);
+    }
+  } catch (_i) {
+    // Ignore by default
+  }
+}
+
 app.prepare().then(() => {
   const server = express();
 
   server.use(sslRedirect());
 
-  server.all('*', (req, res) => {
-    const host = req.get('Host');
-    if (host === 'blog.globalforestwatch.org') {
-      return res.redirect(
-        301,
-        `https://www.globalforestwatch.org/blog${req.originalUrl}`
-      );
+  server.all(/.*/, (req, res) => {
+    // Redirect from non-www to www, but only on actual `production`.
+    // Note that we cannot use `NODE_ENV` for this. Instead we need to use
+    //  the `NEXT_PUBLIC_FEATURE_ENV` environment variable.
+    if (process.env.NEXT_PUBLIC_FEATURE_ENV === 'production') {
+      handleNonWwwToWwwRedirect(req, res);
     }
+
+    // Handle old to new blog url redirect.
+    handleOldBlogUrlRedirect(req, res);
+
     return handle(req, res);
   });
 


### PR DESCRIPTION
## Overview

This PR sets up `301` (permanent) redirects from all `non-www` or `http` urls to their `https://www.` versions. 

**In this PR:** 
  - Changed the `http` to `https` redirect from a `302` (temporary) to a `301` (permanent)  
  - Added a `301` (permanent) redirect from `non-www` to `www` for all pages  
  - Improved the `server.js` (custom `express` server file responsible for the redirects) code documentation on everything redirect related  

## Notes

  - The `http` to `https` redirects work on `staging` and `production` environments.  
    This is set up by the `NODE_ENV` environment variable (which is set to `production` in those environments)
  - The `non-www` to `www` redirects **only** work on `production`. 
    This is because `staging` doesn't support `www` urls
    This is set up by the `NEXT_PUBLIC_FEATURE_ENV` environment variable (which is set to `production` only on the `production` environment)

## Tracking

[FLAG-511](https://gfw.atlassian.net/browse/FLAG-511)

## Testing

**IMPORTANT NOTES:**  

- One may have to clear the browser cache and reload between tests in order for the redirects to work properly.
- `non-www` to `www` redirects will not be applied in `staging`. This is because our current setup doesn't allow `www` URLs in those environments. `http` to `https` is supported though. 

**Local environment**  

1. Run `yarn dev` 
    - Ensure that the local development environment boots up normally  
2. Set `NEXT_PUBLIC_FEATURE_ENV` to `production` locally  
3. Run `yarn build` _to build a production version of the website_  
4. Run `yarn start` _to spin up our custom `nextjs/express` server_
    - Ensure the redirects work as expected   
      _The pages will not load, but one can verify the redirects work in the browser's address bar_  

**Staging environment**  

1.  Set `NEXT_PUBLIC_FEATURE_ENV` _(in the Heroku Config Vars)_ to `staging`, if not set  
    - Ensure the pages load correctly  
    - Ensure the `http` to `https` redirects work as expected  
2. Set `NEXT_PUBLIC_FEATURE_ENV` _(in the Heroku Config Vars)_ to `production`
    - Ensure the redirects work as expected   
      _The pages will not load, but one can verify the redirects work in the browser's address bar_  

